### PR TITLE
Suggestion confirmation

### DIFF
--- a/src/commands/other.rs
+++ b/src/commands/other.rs
@@ -212,7 +212,7 @@ pub async fn suggest(ctx: Context<'_>, #[description="the suggestion to submit"]
         data.webhooks["suggestions"].execute(&ctx.discord().http, false, |b| {b
             .content(suggestion)
             .avatar_url(author.face())
-            .username(format!("{}#{} ({})", author.name, author.discriminator, author.id))
+            .username(format!("{}#{:04} ({})", author.name, author.discriminator, author.id))
         }).await?;
     }
 

--- a/src/commands/other.rs
+++ b/src/commands/other.rs
@@ -18,8 +18,9 @@ use poise::serenity_prelude as serenity;
 use num_format::{Locale, ToFormattedString};
 
 use crate::constants::{OPTION_SEPERATORS};
-use crate::funcs::{fetch_audio, parse_user_or_guild, refresh_kind};
+use crate::funcs::{bool_button, fetch_audio, parse_user_or_guild, refresh_kind};
 use crate::structs::{Context, TTSMode, OptionTryUnwrap, CommandResult, PoiseContextExt};
+use crate::require;
 
 /// Shows how long TTS Bot has been online
 #[poise::command(category="Extra Commands", prefix_command, slash_command, required_bot_permissions="SEND_MESSAGES")]
@@ -204,6 +205,11 @@ pub async fn suggest(ctx: Context<'_>, #[description="the suggestion to submit"]
     if suggestion.to_lowercase().replace('<', ">") == "suggestion" {
         ctx.say("Hey! You are meant to replace `<suggestion>` with your actual suggestion!").await?;
         return Ok(())
+    }
+
+    if !require!(bool_button(ctx, format!("Are you sure you want to make a suggestion to {}?", ctx.discord().cache.current_user_field(|b| b.name.clone())).as_str(), "Yes", "Cancel", None).await?, Ok(())) {
+        ctx.say("Suggestion cancelled").await?;
+        return Ok(());
     }
 
     let data = ctx.data();

--- a/src/commands/owner.rs
+++ b/src/commands/owner.rs
@@ -134,10 +134,10 @@ pub async fn dm_generic(
         .title("Message from the developers:")
         .description(message)
         .author(|a| {a
-            .name(format!("{}#{}", author.name, author.discriminator))
+            .name(format!("{}#{:04}", author.name, author.discriminator))
             .icon_url(author.face())
         })
     })}).await?;
 
-    Ok((format!("Sent message to {}#{}:", todm.name, todm.discriminator), sent.embeds.into_iter().next().unwrap()))
+    Ok((format!("Sent message to {}#{:04}:", todm.name, todm.discriminator), sent.embeds.into_iter().next().unwrap()))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -706,8 +706,9 @@ async fn process_support_dm(
         serenity::Channel::Guild(channel) => {
             // Check support server trusted member replies to a DM, if so, pass it through
             if let Some(reference) = &message.message_reference {
-                if data.config.main_server != channel.guild_id.0
-                    || ["dm_logs", "suggestions"].contains(&channel.name.as_str())
+                if ![data.webhooks["dm_logs"].channel_id.try_unwrap()?,
+                     data.webhooks["suggestions"].channel_id.try_unwrap()?]
+                    .contains(&channel.id)
                 {
                     return Ok(());
                 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -756,7 +756,7 @@ async fn process_support_dm(
                 } else if content.as_str() == "help" {
                     channel.say(&ctx.http, "We cannot help you unless you ask a question, if you want the help command just do `-help`!").await?;
                 } else if !userinfo.dm_blocked {
-                    let display_name = format!("{}#{}", &message.author.name, &message.author.discriminator);
+                    let display_name = format!("{}#{:04}", &message.author.name, &message.author.discriminator);
                     let webhook_username = format!("{} ({})", display_name, message.author.id.0);
                     let paths: Vec<serenity::AttachmentType<'_>> = message.attachments.iter()
                         .map(|a| serenity::AttachmentType::Path(Path::new(&a.url)))


### PR DESCRIPTION
Adds a confirmation to `/suggest`. Also adds padding to discriminators in some places (#0753 instead of #753) and fixes replies in #suggestions and #dm_logs.
![image](https://user-images.githubusercontent.com/30369708/164607186-6dce53dd-c47c-4a0f-a218-f8437189e81f.png)